### PR TITLE
Move to builder

### DIFF
--- a/crates/crabe_decision/src/action/move_to.rs
+++ b/crates/crabe_decision/src/action/move_to.rs
@@ -223,17 +223,13 @@ impl Action for MoveTo {
             let mut order = Vector3::new(0., 0., 0.);
             let ti = frame_inv(robot_frame(robot));
 
-            // if target_x is none, set it to the current x position of the robot
-            if self.target_x.is_none(){
-                self.target_x = Some(robot.pose.position.x);
-            }
-            // if target_y is none, set it to the current y position of the robot
-            if self.target_y.is_none(){
-                self.target_y = Some(robot.pose.position.y);
-            }
+            // set the target position and orientation to the current position and orientation of the robot if they are not set
+            self.target_x.get_or_insert_with(|| robot.pose.position.x);
+            self.target_y.get_or_insert_with(|| robot.pose.position.y);
+            self.orientation.get_or_insert_with(|| robot.pose.orientation);
 
             // calculate position command 
-            let mut target = Point2::new(self.target_x.unwrap_or(robot.pose.position.x), self.target_y.unwrap_or(robot.pose.position.y));
+            let mut target = Point2::new(self.target_x.unwrap(), self.target_y.unwrap());
             if id != KEEPER_ID{
                 target = penalty_zone_prevention(&robot.pose.position, &target, world);
             }
@@ -246,8 +242,7 @@ impl Action for MoveTo {
             order.y = target_in_robot[1];
 
             // calculate orientation command
-            let mut orientation = self.orientation.unwrap_or(robot.pose.orientation);
-            let error_orientation = angle_difference(orientation, robot.pose.orientation);
+            let orientation = self.orientation.unwrap();
             order.z = angle_difference(orientation, robot.pose.orientation);
 
             // if the robot is close to the target orientation, it will stop this moveto

--- a/crates/crabe_decision/src/action/move_to.rs
+++ b/crates/crabe_decision/src/action/move_to.rs
@@ -107,30 +107,45 @@ impl MoveTo {
     }
 
     /// Set the kicker to be used by the robot.
+    /// 
+    /// # Arguments
+    /// * `kicker`: The kicker to be used by the robot.
     pub fn set_kick(mut self, kicker: Kick) -> Self {
         self.kicker = Some(kicker);
         self
     }
 
     /// Set the dribbler speed of the robot.
+    /// 
+    /// # Arguments
+    /// * `dribbler`: The dribbler speed of the robot.
     pub fn set_dribbler(mut self, dribbler: f32) -> Self {
         self.dribbler = dribbler;
         self
     }
 
     /// Set the x target position of the robot.
+    /// 
+    /// # Arguments
+    /// * `x`: The x target position of the robot.
     pub fn set_x(mut self, x: f64) -> Self {
         self.target_x = Some(x);
         self
     }
 
-    /// Set the y target position of the robot.
+    /// Set the y target position of the robot. 
+    /// 
+    /// # Arguments
+    /// * `y`: The y target position of the robot.
     pub fn set_y(mut self, y: f64) -> Self {
         self.target_y = Some(y);
         self
     }
 
-    /// Set the target position of the robot as a point.
+    /// Set the target position of the robot.
+    /// 
+    /// # Arguments
+    /// * `target`: A 2d point representing the target position of the robot.
     pub fn set_target(mut self, target: Point2<f64>) -> Self {
         self.target_x = Some(target.x);
         self.target_y = Some(target.y);
@@ -138,6 +153,9 @@ impl MoveTo {
     }
 
     /// Set the target orientation of the robot.
+    /// 
+    /// # Arguments
+    /// * `orientation`: The target angle of the robot.
     pub fn set_orientation(mut self, orientation: f64) -> Self {
         self.orientation = Some(orientation);
         self

--- a/crates/crabe_decision/src/action/move_to.rs
+++ b/crates/crabe_decision/src/action/move_to.rs
@@ -16,9 +16,10 @@ pub struct MoveTo {
     /// The current state of the action.
     pub state: State,
     /// The target position to move to.
-    pub target: Point2<f64>,
+    pub target_x: Option<f64>,
+    pub target_y: Option<f64>,
     /// The target orientation of the robot.
-    pub orientation: f64,
+    pub orientation: Option<f64>,
     pub charge: bool,
     pub dribbler: f32,
     pub kicker: Option<Kick>,
@@ -30,7 +31,8 @@ impl From<&mut MoveTo> for MoveTo {
     fn from(other: &mut MoveTo) -> MoveTo {
         MoveTo {
             state: other.state,
-            target: other.target,
+            target_x: other.target_x,
+            target_y: other.target_y,
             orientation: other.orientation,
             charge: other.charge,
             dribbler: other.dribbler,
@@ -42,13 +44,29 @@ impl From<&mut MoveTo> for MoveTo {
 }
 
 impl MoveTo {
-    /// Creates a new `MoveTo` instance.
+    /// Creates a new `MoveTo` instance where the default target position and orientation are set to the current position and orientation of the robot.
+    /// You can then use the builder pattern to modify parameters.
+    pub fn new() -> Self {
+        Self {
+            state: State::Running,
+            target_x: None,
+            target_y: None,
+            orientation: None,
+            charge: false,
+            dribbler: 0.,
+            kicker: None,
+            fast: true,
+            avoidance: true
+        }
+    }
+
+    /// Creates a new `MoveTo` instance by specifying all the params manually (DO NOT USE THIS FUNCTION, the only purpose is to handle previously existing code)
     ///
     /// # Arguments
     ///
     /// * `target`: The target position on the field to move the robot to.
     /// * `orientation`: The target orientation of the robot.
-    pub fn new(
+    pub fn new_all_params(
         target: Point2<f64>,
         orientation: f64,
         dribbler: f32,
@@ -59,14 +77,70 @@ impl MoveTo {
     ) -> Self {
         Self {
             state: State::Running,
-            target,
-            orientation,
+            target_x: Some(target.x),
+            target_y: Some(target.y),
+            orientation: Some(orientation),
             charge,
             dribbler,
             kicker,
             fast,
             avoidance
         }
+    }
+
+    /// Desactivate obstacle avoidance.
+    pub fn no_avoidance(mut self) -> Self {
+        self.avoidance = false;
+        self
+    }
+
+    /// Makes the robot move slower towards the target position and orientation.
+    pub fn slowly(mut self) -> Self {
+        self.fast = false;
+        self
+    }
+
+    /// Activate the charging mode of the robot.
+    pub fn charging(mut self) -> Self {
+        self.charge = true;
+        self
+    }
+
+    /// Set the kicker to be used by the robot.
+    pub fn set_kick(mut self, kicker: Kick) -> Self {
+        self.kicker = Some(kicker);
+        self
+    }
+
+    /// Set the dribbler speed of the robot.
+    pub fn set_dribbler(mut self, dribbler: f32) -> Self {
+        self.dribbler = dribbler;
+        self
+    }
+
+    /// Set the x target position of the robot.
+    pub fn set_x(mut self, x: f64) -> Self {
+        self.target_x = Some(x);
+        self
+    }
+
+    /// Set the y target position of the robot.
+    pub fn set_y(mut self, y: f64) -> Self {
+        self.target_y = Some(y);
+        self
+    }
+
+    /// Set the target position of the robot as a point.
+    pub fn set_target(mut self, target: Point2<f64>) -> Self {
+        self.target_x = Some(target.x);
+        self.target_y = Some(target.y);
+        self
+    }
+
+    /// Set the target orientation of the robot.
+    pub fn set_orientation(mut self, orientation: f64) -> Self {
+        self.orientation = Some(orientation);
+        self
     }
 }
 
@@ -128,38 +202,48 @@ impl Action for MoveTo {
     /// * `tools`: A collection of external tools used by the action, such as a viewer.
     fn compute_order(&mut self, id: u8, world: &World, _tools: &mut ToolData) -> Command {
         if let Some(robot) = world.allies_bot.get(&id) {
-            let mut target = self.target;
+            let mut order = Vector3::new(0., 0., 0.);
+            let ti = frame_inv(robot_frame(robot));
+
+            // if target_x is none, set it to the current x position of the robot
+            if self.target_x.is_none(){
+                self.target_x = Some(robot.pose.position.x);
+            }
+            // if target_y is none, set it to the current y position of the robot
+            if self.target_y.is_none(){
+                self.target_y = Some(robot.pose.position.y);
+            }
+
+            // calculate position command 
+            let mut target = Point2::new(self.target_x.unwrap_or(robot.pose.position.x), self.target_y.unwrap_or(robot.pose.position.y));
             if id != KEEPER_ID{
-                target = penalty_zone_prevention(&robot.pose.position, &self.target, world)
+                target = penalty_zone_prevention(&robot.pose.position, &target, world);
             }
             if self.avoidance{
                 target = obstacle_avoidance(&target, robot, world, _tools);
             }
-            let ti = frame_inv(robot_frame(robot));
-            let target_in_robot = ti * Point2::new(target.x, target.y);
             _tools.annotations.add_circle(vec!["target".to_string(), id.to_string()].join("-"),Circle::new(target, 0.1));
-            let error_orientation = angle_difference(self.orientation, robot.pose.orientation);
-            let error_x = target_in_robot[0];
-            let error_y = target_in_robot[1];
-            let arrived = Vector3::new(error_x, error_y, error_orientation).norm() < ERR_TOLERANCE;
+            let target_in_robot = ti * Point2::new(target.x, target.y);
+            order.x = target_in_robot[0];
+            order.y = target_in_robot[1];
+
+            // calculate orientation command
+            let mut orientation = self.orientation.unwrap_or(robot.pose.orientation);
+            let error_orientation = angle_difference(orientation, robot.pose.orientation);
+            order.z = angle_difference(orientation, robot.pose.orientation);
+
+            // if the robot is close to the target orientation, it will stop this moveto
+            let arrived = order.norm() < ERR_TOLERANCE;
             if arrived {
                 self.state = State::Done;
             }
 
-            let order = 
-            if self.fast {
-                Vector3::new(
-                GOTO_SPEED_FAST * error_x,
-                GOTO_SPEED_FAST * error_y,
-                GOTO_ROTATION_FAST * error_orientation,
-                )
-            } else {
-                Vector3::new(
-                GOTO_SPEED * error_x,
-                GOTO_SPEED * error_y,
-                GOTO_ROTATION * error_orientation,
-                )
-            };
+            // mutliply by the speed factors
+            let speed = if self.fast { GOTO_SPEED_FAST } else { GOTO_SPEED };
+            let rotation = if self.fast { GOTO_ROTATION_FAST } else { GOTO_ROTATION };
+            order.x = speed * order.x;
+            order.y = speed * order.y;
+            order.z = rotation * order.z;
             // Command::default()
 
             Command {

--- a/crates/crabe_decision/src/strategy/basics/comeback.rs
+++ b/crates/crabe_decision/src/strategy/basics/comeback.rs
@@ -31,9 +31,9 @@ pub fn comeback(
             } else {
                 Point2::new(target.x, target.y - 1.0)
             };
-            return MoveTo::new(new_target, orientation, 0.0, false, None, true, true);
+            return MoveTo::new_all_params(new_target, orientation, 0.0, false, None, true, true);
         }
     }
     
-    MoveTo::new(target, orientation, 0.0, false, None, true , true)
+    MoveTo::new_all_params(target, orientation, 0.0, false, None, true , true)
 }

--- a/crates/crabe_decision/src/strategy/basics/intercept.rs
+++ b/crates/crabe_decision/src/strategy/basics/intercept.rs
@@ -10,7 +10,7 @@ pub fn intercept(
     let ball_position = ball.position_2d();
     let orientation = vectors::angle_to_point(robot.pose.position,ball_position);
     if ball.velocity.norm() < 0.4 {
-        return MoveTo::new(ball_position, orientation, 0., false, None, true, true);
+        return MoveTo::new_all_params(ball_position, orientation, 0., false, None, true, true);
     }
     let trajectory = Line::new(ball_position, ball_position + ball.velocity.xy().normalize() * 100.);
     let target = trajectory.closest_point_on_segment(&robot.pose.position);
@@ -18,5 +18,5 @@ pub fn intercept(
     if robot.distance(&ball_position) < 0.2 {
         dribbler = 1.;
     }
-    MoveTo::new(target, orientation, dribbler, false, None, true, false)
+    MoveTo::new_all_params(target, orientation, dribbler, false, None, true, false)
 }

--- a/crates/crabe_decision/src/strategy/basics/move_away_from_point.rs
+++ b/crates/crabe_decision/src/strategy/basics/move_away_from_point.rs
@@ -20,7 +20,7 @@ pub fn move_away(
     if dist_robot_target < distance{
         if dist_robot_target == 0. {
             return Some(
-                MoveTo::new( 
+                MoveTo::new_all_params( 
                 Point2::new(100.,100.),
                 0., 
                 0., 
@@ -40,7 +40,7 @@ pub fn move_away(
             target = away_point + dir;
         }
         return Some(
-            MoveTo::new(target,
+            MoveTo::new_all_params(target,
              orientation, 
             0., 
             false, 

--- a/crates/crabe_decision/src/strategy/basics/pass.rs
+++ b/crates/crabe_decision/src/strategy/basics/pass.rs
@@ -47,7 +47,7 @@ pub fn pass(
         let kick: Option<Kick> = if dist_to_ball < (world.geometry.robot_radius + world.geometry.ball_radius + 1.) { 
             Some(Kick::StraightKick {  power: 4. }) 
         }else {None};
-        return MoveTo::new(ball_position, vectors::angle_to_point(robot_position,receiver.pose.position), 400.,  true, kick, true, false);
+        return MoveTo::new_all_params(ball_position, vectors::angle_to_point(robot_position,receiver.pose.position), 400.,  true, kick, true, false);
     }
-    MoveTo::new(behind_ball_position, vectors::angle_to_point(robot_position, receiver.pose.position), 0., false, None, true, true)
+    MoveTo::new_all_params(behind_ball_position, vectors::angle_to_point(robot_position, receiver.pose.position), 0., false, None, true, true)
 }

--- a/crates/crabe_decision/src/strategy/basics/shoot.rs
+++ b/crates/crabe_decision/src/strategy/basics/shoot.rs
@@ -47,7 +47,7 @@ pub fn shoot(
         }else {None};
         let dir  = (ball_position - robot_position).normalize()*0.4;
         let target = robot_position + dir;
-        return MoveTo::new(target, vectors::angle_to_point(robot_position,*target_shooting_position), 400.,  true, kick, false, false);
+        return MoveTo::new_all_params(target, vectors::angle_to_point(robot_position,*target_shooting_position), 400.,  true, kick, false, false);
     }
-    MoveTo::new(behind_ball_position, vectors::angle_to_point(robot_position, *target_shooting_position), 0., false, None, true, true)
+    MoveTo::new_all_params(behind_ball_position, vectors::angle_to_point(robot_position, *target_shooting_position), 0., false, None, true, true)
 }

--- a/crates/crabe_decision/src/strategy/defensive/bot_contesting.rs
+++ b/crates/crabe_decision/src/strategy/defensive/bot_contesting.rs
@@ -124,7 +124,7 @@ impl Strategy for BotContesting {
 
         let fast = robot.distance(&enemy.pose.position) > 1.;
 
-        action_wrapper.push(self.id,  MoveTo::new(Point2::new(target.x, target.y), angle , dribble , false , None, fast, true ));
+        action_wrapper.push(self.id,  MoveTo::new_all_params(Point2::new(target.x, target.y), angle , dribble , false , None, fast, true ));
         return false;
     }
 }

--- a/crates/crabe_decision/src/strategy/defensive/bot_marking.rs
+++ b/crates/crabe_decision/src/strategy/defensive/bot_marking.rs
@@ -93,7 +93,7 @@ impl Strategy for BotMarking {
         let ball_velocity_trajectory = Line::new(ball_pos, ball_pos + ball.velocity.xy().normalize() * 100.);
         if ball.velocity.norm() > 0.1 && ball_velocity_trajectory.distance_to_point(&enemy_pos.position) < 1. {
             let target = ball_velocity_trajectory.closest_point_on_segment(&robot_pos.position);
-            action_wrapper.push(self.id,  MoveTo::new(Point2::new(target.x, target.y), angle , dribbler , false , Some(StraightKick { power: 0.0 }), true, true));
+            action_wrapper.push(self.id,  MoveTo::new_all_params(Point2::new(target.x, target.y), angle , dribbler , false , Some(StraightKick { power: 0.0 }), true, true));
         } else {
 
             // VECTEUR BALL -> ENEMY
@@ -101,7 +101,7 @@ impl Strategy for BotMarking {
             let enemy_ball_distance = enemy_to_ball.norm();
             let coef_distance_to_enemy: f64 = world.geometry.robot_radius + 0.2/enemy_ball_distance;
             let target = enemy_pos.position -  Point2::new(enemy_to_ball.x, enemy_to_ball.y)*(-coef_distance_to_enemy);
-            action_wrapper.push(self.id,  MoveTo::new(Point2::new(target.x, target.y), angle , dribbler , false , Some(StraightKick { power: 0.0 }), false, true));
+            action_wrapper.push(self.id,  MoveTo::new_all_params(Point2::new(target.x, target.y), angle , dribbler , false , Some(StraightKick { power: 0.0 }), false, true));
         }
 
         

--- a/crates/crabe_decision/src/strategy/defensive/defense_wall.rs
+++ b/crates/crabe_decision/src/strategy/defensive/defense_wall.rs
@@ -47,7 +47,7 @@ impl DefenseWall {
         let oscillating_value = (0.00005 * 2.0 * std::f64::consts::PI * x).sin() * 0.5 + 0.5;
         let pos = enlarged_penalty.on_penalty_line(oscillating_value);
         for id in self.ids.clone() {
-            action_wrapper.push(id, MoveTo::new(pos, 0., 0., false, None, false, true));
+            action_wrapper.push(id, MoveTo::new_all_params(pos, 0., 0., false, None, false, true));
         }
         false
     }
@@ -167,15 +167,15 @@ impl Strategy for DefenseWall {
                     if let Some(closest_bot_to_ball) = closest{
                         if closest_bot_to_ball.id == robot.id && !enlarged_penalty.is_inside(&ball_pos){
                             let ball_orientation = vectors::angle_to_point(robot.pose.position, ball_pos);
-                            action_wrapper.push(robot.id, MoveTo::new(ball_pos, ball_orientation, 0., true, Some(Kick::StraightKick { power: 4. }), false, avoidance));
+                            action_wrapper.push(robot.id, MoveTo::new_all_params(ball_pos, ball_orientation, 0., true, Some(Kick::StraightKick { power: 4. }), false, avoidance));
                         }else {
-                            action_wrapper.push(robot.id, MoveTo::new(pos_on_penalty_line, orientation, 0., false, None, true, avoidance));
+                            action_wrapper.push(robot.id, MoveTo::new_all_params(pos_on_penalty_line, orientation, 0., false, None, true, avoidance));
                         }
                     }else {
-                        action_wrapper.push(robot.id, MoveTo::new(pos_on_penalty_line, orientation, 0., false, None, true, avoidance));
+                        action_wrapper.push(robot.id, MoveTo::new_all_params(pos_on_penalty_line, orientation, 0., false, None, true, avoidance));
                     }
                 } else {
-                    action_wrapper.push(robot.id, MoveTo::new(pos_on_penalty_line, orientation, 0., false, None, true, avoidance));
+                    action_wrapper.push(robot.id, MoveTo::new_all_params(pos_on_penalty_line, orientation, 0., false, None, true, avoidance));
                 }
                 i+=1;
             }

--- a/crates/crabe_decision/src/strategy/defensive/goal_keeper.rs
+++ b/crates/crabe_decision/src/strategy/defensive/goal_keeper.rs
@@ -128,7 +128,7 @@ impl Strategy for GoalKeeper {
             if let Some(intersection) = self.follow_velocity_trajectory(ball, world){
                 position_target = intersection;
             } else if ball.velocity.norm() < 0.1 && penalty.is_inside(&ball_position) {
-                action_wrapper.push(robot.id, MoveTo::new(ball_position, vectors::angle_to_point(robot.pose.position, ball_position), 0.0, true, Some(Kick::StraightKick { power: 4. }), false, false));
+                action_wrapper.push(robot.id, MoveTo::new_all_params(ball_position, vectors::angle_to_point(robot.pose.position, ball_position), 0.0, true, Some(Kick::StraightKick { power: 4. }), false, false));
                 return false;
             } else if let Some(closest_enemy) = closest_bot_to_point(world.enemies_bot.values().collect(), ball_position){
                 if let Some(intersection) = self.follow_enemy_to_ball_trajectory(ball, world, closest_enemy){
@@ -153,7 +153,7 @@ impl Strategy for GoalKeeper {
         }
 
         // Move the robot to the calculated position and orientation
-        action_wrapper.push(self.id, MoveTo::new(position_target, orientation, 0., false, None, true, false));
+        action_wrapper.push(self.id, MoveTo::new_all_params(position_target, orientation, 0., false, None, true, false));
         false
     }
 

--- a/crates/crabe_decision/src/strategy/formations/latteral_attack.rs
+++ b/crates/crabe_decision/src/strategy/formations/latteral_attack.rs
@@ -73,14 +73,14 @@ impl Strategy for LateralAttack {
             if object_in_bot_trajectory(world, self.id, passer.pose.position, false, false, true).len() > 0 {
                 target = Point2::new(3.5, 1.5);
             }
-            action_wrapper.push(self.id, MoveTo::new(target, angle_to_point(robot.pose.position, passer.pose.position), 0.0, false, None, true, true));
+            action_wrapper.push(self.id, MoveTo::new_all_params(target, angle_to_point(robot.pose.position, passer.pose.position), 0.0, false, None, true, true));
             return false;
         } else {
             target = Point2::new(3.5, -2.);
             if object_in_bot_trajectory(world, self.id, passer.pose.position, false, false, true).len() > 0 {
                 target = Point2::new(3.5, -1.5);
             }
-            action_wrapper.push(self.id, MoveTo::new(target, angle_to_point(robot.pose.position, passer.pose.position), 0.0, false, None, true, true));
+            action_wrapper.push(self.id, MoveTo::new_all_params(target, angle_to_point(robot.pose.position, passer.pose.position), 0.0, false, None, true, true));
             return false;
         } 
 

--- a/crates/crabe_decision/src/strategy/formations/prepare_kick_off.rs
+++ b/crates/crabe_decision/src/strategy/formations/prepare_kick_off.rs
@@ -76,7 +76,7 @@ impl Strategy for PrepareKickOff {
                             let perp = rotate_vector(dir, PI/2.) * (world.geometry.robot_radius * 2. + 0.02);
                             let target_center = ball.position_2d() + dir;
                             let pos_along_block = perp * i as f64;
-                            action_wrapper.push(*id, MoveTo::new(target_center + pos_along_block, angle_to_point(robot.pose.position, ball.position_2d()), 0., false, None, true, true));
+                            action_wrapper.push(*id, MoveTo::new_all_params(target_center + pos_along_block, angle_to_point(robot.pose.position, ball.position_2d()), 0., false, None, true, true));
                             i+=1;
                         }else{}
                     }

--- a/crates/crabe_decision/src/strategy/formations/prepare_start.rs
+++ b/crates/crabe_decision/src/strategy/formations/prepare_start.rs
@@ -53,10 +53,10 @@ impl Strategy for PrepareStart {
             if let Some(robot) = &world.allies_bot.get(id) {
                 let orientation = angle_to_point(robot.pose.position, nalgebra::Point2::new(0.0, 0.0));
                 if *id == KEEPER_ID {
-                    action_wrapper.push(*id, MoveTo::new(world.geometry.ally_goal.line.center(), orientation, 0.0, false, None, true, true));
+                    action_wrapper.push(*id, MoveTo::new_all_params(world.geometry.ally_goal.line.center(), orientation, 0.0, false, None, true, true));
                 } else {
                     let target = nalgebra::Point2::new(world.geometry.ally_penalty.front_line.center().x + 0.2, i as f64 * (world.geometry.robot_radius * 2. + 0.02) - (((self.ids.len() as f64 -2.) / 2.) * (world.geometry.robot_radius * 2. + 0.02)));
-                    action_wrapper.push(*id, MoveTo::new(target, orientation, 0.0, false, None, true, true));
+                    action_wrapper.push(*id, MoveTo::new_all_params(target, orientation, 0.0, false, None, true, true));
                     i += 1;
                 }
             }

--- a/crates/crabe_decision/src/strategy/offensive/receiver.rs
+++ b/crates/crabe_decision/src/strategy/offensive/receiver.rs
@@ -86,7 +86,7 @@ impl Strategy for Receiver {
         if robot.distance(&interception_point) < 0.3 {
             dribbler = 1.;
         }
-        action_wrapper.push(self.id, MoveTo::new(interception_point, vectors::angle_to_point(robot_position,ball.position_2d()), dribbler,  false, None, true, true));
+        action_wrapper.push(self.id, MoveTo::new_all_params(interception_point, vectors::angle_to_point(robot_position,ball.position_2d()), dribbler,  false, None, true, true));
         false
     }
 }

--- a/crates/crabe_decision/src/strategy/testing/aligned.rs
+++ b/crates/crabe_decision/src/strategy/testing/aligned.rs
@@ -50,7 +50,7 @@ impl Strategy for Aligned {
             action_wrapper.clear(*id);
             let offset = 0.15 * ((self.ids.len() as f64) - 1.);
             let dest = Point2::new((i as f64) * 0.3 - offset, 2.0);
-            action_wrapper.push(*id, MoveTo::new(dest, -PI / 4.0, 0.0, false, None, false, true));
+            action_wrapper.push(*id, MoveTo::new_all_params(dest, -PI / 4.0, 0.0, false, None, false, true));
             if *id == 1 {
                 match world.allies_bot.get(id) {
                     Some(bot) => {

--- a/crates/crabe_decision/src/strategy/testing/go_left.rs
+++ b/crates/crabe_decision/src/strategy/testing/go_left.rs
@@ -49,7 +49,7 @@ impl Strategy for GoLeft {
         self.messages.clear();
         action_wrapper.push(
             self.id,
-            MoveTo::new(dest, -PI / 4.0, 0.0, false, None, true, true),
+            MoveTo::new_all_params(dest, -PI / 4.0, 0.0, false, None, true, true),
         );
         match world.allies_bot.get(&self.id) {
             Some(bot) => {  

--- a/crates/crabe_decision/src/strategy/testing/go_right.rs
+++ b/crates/crabe_decision/src/strategy/testing/go_right.rs
@@ -49,7 +49,7 @@ impl Strategy for GoRight {
         self.messages.clear();
         action_wrapper.push(
             self.id,
-            MoveTo::new(dest, -PI / 4.0, 0.0, false, None, true, true),
+            MoveTo::new_all_params(dest, -PI / 4.0, 0.0, false, None, true, true),
         );
         match world.allies_bot.get(&self.id) {
             Some(bot) => {  

--- a/crates/crabe_decision/src/strategy/testing/square.rs
+++ b/crates/crabe_decision/src/strategy/testing/square.rs
@@ -62,19 +62,19 @@ impl Strategy for Square {
     ) -> bool {
         action_wrapper.push(
             self.id,
-            MoveTo::new(Point2::new(-1.0, 1.0), -PI / 4., 0.0, false, None, true, true),
+            MoveTo::new().set_x(-1.0).set_y(1.0).set_orientation(-PI / 4.),
         );
         action_wrapper.push(
             self.id,
-            MoveTo::new(Point2::new(1.0, 1.0), -3.* PI / 4., 0.0, false, None, true, true),
+            MoveTo::new().set_x(1.0).set_orientation(-3.* PI / 4.),
         );
         action_wrapper.push(
             self.id,
-            MoveTo::new(Point2::new(1.0, -1.0), 3.* PI / 4., 0.0, false, None, true, true),
+            MoveTo::new().set_y(-1.0).set_orientation(3.* PI / 4.),
         );
         action_wrapper.push(
             self.id,
-            MoveTo::new(Point2::new(-1.0, -1.0), PI / 4., 0.0, false, None, true, true),
+            MoveTo::new().set_x(-1.0).set_orientation(PI / 4.),
         );
         true
     }

--- a/crates/crabe_decision/src/strategy/testing/square.rs
+++ b/crates/crabe_decision/src/strategy/testing/square.rs
@@ -66,15 +66,15 @@ impl Strategy for Square {
         );
         action_wrapper.push(
             self.id,
-            MoveTo::new().set_x(1.0).set_orientation(-3.* PI / 4.),
+            MoveTo::new().set_x(1.0).set_y(1.0).set_orientation(-3.* PI / 4.),
         );
         action_wrapper.push(
             self.id,
-            MoveTo::new().set_y(-1.0).set_orientation(3.* PI / 4.),
+            MoveTo::new().set_x(1.0).set_y(-1.0).set_orientation(3.* PI / 4.),
         );
         action_wrapper.push(
             self.id,
-            MoveTo::new().set_x(-1.0).set_orientation(PI / 4.),
+            MoveTo::new().set_x(-1.0).set_y(-1.0).set_orientation(PI / 4.),
         );
         true
     }

--- a/crates/crabe_decision/src/strategy/testing/test_vision_moveto.rs
+++ b/crates/crabe_decision/src/strategy/testing/test_vision_moveto.rs
@@ -91,7 +91,7 @@ impl Strategy for TestVisionMoveTo {
             .filter(|(ally_id, _)| self.ids.contains(ally_id))
             .for_each(|(ally_id, ally_info)| {
                 let target = Point2::new(-(*ally_id as f64).div(2.), y_target);
-                action_wrapper.push(*ally_id, MoveTo::new(target, FRAC_PI_6 * (*ally_id as f64), 0.,false , None, false , true));
+                action_wrapper.push(*ally_id, MoveTo::new_all_params(target, FRAC_PI_6 * (*ally_id as f64), 0.,false , None, false , true));
                 change_status = change_status && distance(&target, &ally_info.pose.position) <= DIST_TARGET_REACHED
             });
         if change_status {


### PR DESCRIPTION
Change the way we create moveto commands
Now you just have to call `MoveTo::new()` where the default target will be the current robot position and orientation
You can then call set_target, set_orientation, set_x, set_x, and others function to build your move to command
It will look like this for example
`MoveTo::new().set_x(-1.0).set_y(1.0).set_orientation(-PI / 4.).no_avoidance()`